### PR TITLE
Do not append digest to the bootloader bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ sdkconfig.old
 version.txt
 components/arduino_tinyusb/tinyusb/
 dependencies.lock
+tools/esptool/

--- a/tools/copy-bootloader.sh
+++ b/tools/copy-bootloader.sh
@@ -10,4 +10,11 @@ source ./tools/config.sh
 echo "Copying bootloader: $AR_SDK/bin/bootloader_$BOOTCONF.bin"
 
 mkdir -p "$AR_SDK/bin"
-cp "build/bootloader/bootloader.bin" "$AR_SDK/bin/bootloader_$BOOTCONF.bin"
+
+# Workaround for getting the bootloaders to be flashable with esptool v4.x
+# It might still be needed for IDF5, but using the included esptool instead
+#cp "build/bootloader/bootloader.bin" "$AR_SDK/bin/bootloader_$BOOTCONF.bin"
+if [ ! -e "tools/esptool" ]; then
+	git clone https://github.com/espressif/esptool tools/esptool
+fi
+./tools/esptool/esptool.py --chip "$IDF_TARGET" elf2image --dont-append-digest "build/bootloader/bootloader.elf" -o "$AR_SDK/bin/bootloader_$BOOTCONF.bin"


### PR DESCRIPTION
Allows the bootloaders to be flashed with esptool v4 on devices with different size flash