### PR TITLE
README.md: Add jq as dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tested on Ubuntu (32 and 64 bit), Raspberry Pi and MacOS.
 
 ### Build on Ubuntu and Raspberry Pi
 ```bash
-sudo apt-get install git wget curl libssl-dev libncurses-dev flex bison gperf python python-pip python-setuptools python-serial python-click python-cryptography python-future python-pyparsing python-pyelftools cmake ninja-build ccache
+sudo apt-get install git wget curl libssl-dev libncurses-dev flex bison gperf python python-pip python-setuptools python-serial python-click python-cryptography python-future python-pyparsing python-pyelftools cmake ninja-build ccache jq
 sudo pip install --upgrade pip
 git clone https://github.com/espressif/esp32-arduino-lib-builder
 cd esp32-arduino-lib-builder


### PR DESCRIPTION
jq is not preinstalled on a fresh Ubuntu installation.