### PR TITLE
Added config to detect lib_builder is used.

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -13,3 +13,7 @@ config LIB_BUILDER_FLASHFREQ
     default "40m" if ESPTOOLPY_FLASHFREQ_40M
     default "26m" if ESPTOOLPY_FLASHFREQ_26M
     default "20m" if ESPTOOLPY_FLASHFREQ_20M
+
+config LIB_BUILDER_COMPILE
+    bool
+    default y


### PR DESCRIPTION
Adding this config will let other libraries (Rainmaker, Insights, etc) compile code that is only required for Arduino.