### PR TITLE
Update PlatformIO build script templates

### DIFF
--- a/configs/pio_end.txt
+++ b/configs/pio_end.txt
@@ -2,9 +2,9 @@
         "ESP32",
         ("F_CPU", "$BOARD_F_CPU"),
         ("ARDUINO", 10812),
-        ("ARDUINO_VARIANT", '\\"%s\\"' % env.BoardConfig().get("build.variant").replace('"', "")),
-        ("ARDUINO_BOARD", '\\"%s\\"' % env.BoardConfig().get("name").replace('"', "")),
-        "ARDUINO_PARTITION_%s" % basename(env.BoardConfig().get(
+        ("ARDUINO_VARIANT", '\\"%s\\"' % board_config.get("build.variant").replace('"', "")),
+        ("ARDUINO_BOARD", '\\"%s\\"' % board_config.get("name").replace('"', "")),
+        "ARDUINO_PARTITION_%s" % basename(board_config.get(
             "build.partitions", "default.csv")).replace(".csv", "").replace("-", "_")
     ]
 )

--- a/configs/pio_start.txt
+++ b/configs/pio_start.txt
@@ -31,5 +31,10 @@ from SCons.Script import DefaultEnvironment
 env = DefaultEnvironment()
 
 FRAMEWORK_DIR = env.PioPlatform().get_package_dir("framework-arduinoespressif32")
+FRAMEWORK_SDK_DIR = env.PioPlatform().get_package_dir(
+    "framework-arduinoespressif32-libs"
+)
+
+board_config = env.BoardConfig()
 
 env.Append(

--- a/tools/config.sh
+++ b/tools/config.sh
@@ -45,7 +45,7 @@ AR_TOOLS="$AR_OUT/tools"
 AR_PLATFORM_TXT="$AR_OUT/platform.txt"
 AR_GEN_PART_PY="$AR_TOOLS/gen_esp32part.py"
 AR_SDK="$AR_TOOLS/esp32-arduino-libs/$IDF_TARGET"
-PIO_SDK="FRAMEWORK_DIR, \"tools\", \"esp32-arduino-libs\", \"$IDF_TARGET\""
+PIO_SDK="FRAMEWORK_SDK_DIR, \"$IDF_TARGET\""
 TOOLS_JSON_OUT="$AR_TOOLS/esp32-arduino-libs"
 IDF_LIBS_DIR="$AR_ROOT/../esp32-arduino-libs"
 

--- a/tools/copy-libs.sh
+++ b/tools/copy-libs.sh
@@ -404,8 +404,8 @@ for item; do
 		done
 	fi
 done
-echo "        join($PIO_SDK, env.BoardConfig().get(\"build.arduino.memory_type\", (env.BoardConfig().get(\"build.flash_mode\", \"dio\") + \"_$OCT_PSRAM\")), \"include\")," >> "$AR_PLATFORMIO_PY"
-echo "        join(FRAMEWORK_DIR, \"cores\", env.BoardConfig().get(\"build.core\"))" >> "$AR_PLATFORMIO_PY"
+echo "        join($PIO_SDK, board_config.get(\"build.arduino.memory_type\", (board_config.get(\"build.flash_mode\", \"dio\") + \"_$OCT_PSRAM\")), \"include\")," >> "$AR_PLATFORMIO_PY"
+echo "        join(FRAMEWORK_DIR, \"cores\", board_config.get(\"build.core\"))" >> "$AR_PLATFORMIO_PY"
 echo "    ]," >> "$AR_PLATFORMIO_PY"
 echo "" >> "$AR_PLATFORMIO_PY"
 
@@ -429,7 +429,7 @@ done
 echo "    LIBPATH=[" >> "$AR_PLATFORMIO_PY"
 echo "        join($PIO_SDK, \"lib\")," >> "$AR_PLATFORMIO_PY"
 echo "        join($PIO_SDK, \"ld\")," >> "$AR_PLATFORMIO_PY"
-echo "        join($PIO_SDK, env.BoardConfig().get(\"build.arduino.memory_type\", (env.BoardConfig().get(\"build.flash_mode\", \"dio\") + \"_$OCT_PSRAM\")))" >> "$AR_PLATFORMIO_PY"
+echo "        join($PIO_SDK, board_config.get(\"build.arduino.memory_type\", (board_config.get(\"build.flash_mode\", \"dio\") + \"_$OCT_PSRAM\")))" >> "$AR_PLATFORMIO_PY"
 echo "    ]," >> "$AR_PLATFORMIO_PY"
 echo "" >> "$AR_PLATFORMIO_PY"
 


### PR DESCRIPTION
This PR contains updates for the upcoming core v3.0:
- Precompiled SDK libraries are now moved to a new `framework-arduinoespressif32-libs` package
- Refactored frequent `env.BoardConfig()` calls for better performance

cc @me-no-dev 