### PR TITLE
Using most IDF Managed Components instead of git-clone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,6 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-set(RMAKER_PATH ${CMAKE_SOURCE_DIR}/components/esp-rainmaker)
-set(INSIGHTS_PATH ${RMAKER_PATH}/components/esp-insights)
-
-set(EXTRA_COMPONENT_DIRS ${INSIGHTS_PATH}/components ${RMAKER_PATH}/components)
-
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(arduino-lib-builder)
 
@@ -15,7 +10,7 @@ idf_build_get_property(elf EXECUTABLE GENERATOR_EXPRESSION)
 add_custom_command(
 	OUTPUT "idf_libs" 
 	COMMAND ${CMAKE_SOURCE_DIR}/tools/copy-libs.sh ${IDF_TARGET} "${CONFIG_LIB_BUILDER_FLASHMODE}" "${CONFIG_SPIRAM_MODE_OCT}" "${CONFIG_IDF_TARGET_ARCH_XTENSA}"
-	DEPENDS all 
+	DEPENDS ${elf}
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} 
 	VERBATIM
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,3 +33,9 @@ add_custom_command(
 	VERBATIM
 )
 add_custom_target(mem-variant DEPENDS "mem_variant")
+
+if(IDF_TARGET MATCHES "esp32s3")
+	set(SR_MODELS_PATH ${CMAKE_SOURCE_DIR}/managed_components/espressif__esp-sr)
+	set(EXTRA_COMPONENT_DIRS ${SR_MODELS_PATH})
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,3 @@ add_custom_command(
 	VERBATIM
 )
 add_custom_target(mem-variant DEPENDS "mem_variant")
-
-if(IDF_TARGET MATCHES "esp32s3")
-	set(SR_MODELS_PATH ${CMAKE_SOURCE_DIR}/managed_components/espressif__esp-sr)
-	set(EXTRA_COMPONENT_DIRS ${SR_MODELS_PATH})
-endif()
-

--- a/build.sh
+++ b/build.sh
@@ -187,6 +187,19 @@ for target_json in `jq -c '.targets[]' configs/builds.json`; do
     idf.py -DIDF_TARGET="$target" -DSDKCONFIG_DEFAULTS="$idf_libs_configs" idf_libs
     if [ $? -ne 0 ]; then exit 1; fi
 
+    if [ "$target" == "esp32s3" ]; then
+        idf.py -DIDF_TARGET="$target" -DSDKCONFIG_DEFAULTS="$idf_libs_configs" srmodels_bin
+        if [ $? -ne 0 ]; then exit 1; fi
+        AR_SDK="$AR_TOOLS/esp32-arduino-libs/$target"
+        # sr model.bin
+        if [ -f "build/srmodels/srmodels.bin" ]; then
+            echo "$AR_SDK/esp_sr"
+            mkdir -p "$AR_SDK/esp_sr"
+            cp -f "build/srmodels/srmodels.bin" "$AR_SDK/esp_sr/"
+            cp -f "partitions.csv" "$AR_SDK/esp_sr/"
+        fi
+    fi
+
     # Build Bootloaders
     for boot_conf in `echo "$target_json" | jq -c '.bootloaders[]'`; do
         bootloader_configs="$main_configs"

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -14,6 +14,10 @@ dependencies:
     require: public
     rules:
       - if: "target in [esp32s3]"
+    espressif/esp-sr:
+    version: "^1.4.2"
+    rules:
+      - if: "target in [esp32, esp32s3]"
 
   # esp-sr: "^1.3.1"
   # esp32-camera: "^2.0.4"

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -2,7 +2,9 @@ dependencies:
   # Required IDF version
   idf: ">=5.1"
   espressif/esp32-camera:
+    version: "*"
     git: https://github.com/espressif/esp32-camera.git
+    require: public
   espressif/esp-tflite-micro:
     version: ">=1.2.0"
     require: public

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,7 +1,8 @@
 dependencies:
   # Required IDF version
   idf: ">=5.1"
-  espressif/esp32-camera: "^2.0.5"  
+  espressif/esp32-camera:
+    git: https://github.com/espressif/esp32-camera.git
   espressif/esp-tflite-micro:
     version: ">=1.2.0"
     require: public

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -10,7 +10,7 @@ dependencies:
     path: ../components/esp-dl
     require: public
     rules:
-      - if: "target in [esp32, esp32s3]"
+      - if: "target in [esp32s3]"
 
   # esp-sr: "^1.3.1"
   # esp32-camera: "^2.0.4"

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,10 +1,15 @@
 dependencies:
   # Required IDF version
   idf: ">=5.1"
-
-  mdns: "^1.1.0"
-  chmorgan/esp-libhelix-mp3: "1.0.3"
-  esp-dsp: "^1.3.4"
+  espressif/esp-tflite-micro:
+    version: ">=1.2.0"
+    require: public
+  espressif/esp-dl:
+    version: ">=2.0.0"
+    path: ../components/esp-dl
+    require: public
+    rules:
+      - if: "target in [esp32, esp32s3]"
 
   # esp-sr: "^1.3.1"
   # esp32-camera: "^2.0.4"

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -14,10 +14,10 @@ dependencies:
     require: public
     rules:
       - if: "target in [esp32s3]"
-    espressif/esp-sr:
-    version: "^1.4.2"
+  espressif/esp-sr:
+    version: ">=1.4.2"
     rules:
-      - if: "target in [esp32, esp32s3]"
+      - if: "target in [esp32s3]"
 
   # esp-sr: "^1.3.1"
   # esp32-camera: "^2.0.4"

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,6 +1,7 @@
 dependencies:
   # Required IDF version
   idf: ">=5.1"
+  espressif/esp32-camera: "^2.0.5"  
   espressif/esp-tflite-micro:
     version: ">=1.2.0"
     require: public

--- a/tools/copy-libs.sh
+++ b/tools/copy-libs.sh
@@ -478,13 +478,6 @@ echo -n "$LD_FLAGS" > "$FLAGS_DIR/ld_flags"
 echo -n "$LD_SCRIPTS" > "$FLAGS_DIR/ld_scripts"
 echo -n "$AR_LIBS" > "$FLAGS_DIR/ld_libs"
 
-# sr model.bin
-if [ -f "build/srmodels/srmodels.bin" ]; then
-	mkdir -p "$AR_SDK/esp_sr"
-	cp -f "build/srmodels/srmodels.bin" "$AR_SDK/esp_sr/"
-	cp -f "partitions.csv" "$AR_SDK/esp_sr/"
-fi
-
 # sdkconfig
 cp -f "sdkconfig" "$AR_SDK/sdkconfig"
 

--- a/tools/update-components.sh
+++ b/tools/update-components.sh
@@ -13,107 +13,107 @@ TFLITE_REPO_URL="https://github.com/espressif/tflite-micro-esp-examples.git"
 #
 # CLONE/UPDATE ESP32-CAMERA
 #
-echo "Updating ESP32 Camera..."
-if [ ! -d "$AR_COMPS/esp32-camera" ]; then
-	git clone $CAMERA_REPO_URL "$AR_COMPS/esp32-camera"
-else
-	git -C "$AR_COMPS/esp32-camera" fetch && \
-	git -C "$AR_COMPS/esp32-camera" pull --ff-only
-fi
-if [ $? -ne 0 ]; then exit 1; fi
+#echo "Updating ESP32 Camera..."
+#if [ ! -d "$AR_COMPS/esp32-camera" ]; then
+#       git clone $CAMERA_REPO_URL "$AR_COMPS/esp32-camera"
+#else
+#       git -C "$AR_COMPS/esp32-camera" fetch && \
+#       git -C "$AR_COMPS/esp32-camera" pull --ff-only
+#fi
+#if [ $? -ne 0 ]; then exit 1; fi
 
 #
 # CLONE/UPDATE ESP-DL
 #
 echo "Updating ESP-DL..."
 if [ ! -d "$AR_COMPS/esp-dl" ]; then
-	git clone $DL_REPO_URL "$AR_COMPS/esp-dl"
-	#this is a temp measure to fix build issue
-	mv "$AR_COMPS/esp-dl/CMakeLists.txt" "$AR_COMPS/esp-dl/CMakeListsOld.txt"
-	echo "idf_build_get_property(target IDF_TARGET)" > "$AR_COMPS/esp-dl/CMakeLists.txt"
-	echo "if(NOT \${IDF_TARGET} STREQUAL \"esp32c6\" AND NOT \${IDF_TARGET} STREQUAL \"esp32h2\")" >> "$AR_COMPS/esp-dl/CMakeLists.txt"
-	cat "$AR_COMPS/esp-dl/CMakeListsOld.txt" >> "$AR_COMPS/esp-dl/CMakeLists.txt"
-	echo "endif()" >> "$AR_COMPS/esp-dl/CMakeLists.txt"
-	rm -rf "$AR_COMPS/esp-dl/CMakeListsOld.txt"
+        git clone $DL_REPO_URL "$AR_COMPS/esp-dl"
+        #this is a temp measure to fix build issue
+        mv "$AR_COMPS/esp-dl/CMakeLists.txt" "$AR_COMPS/esp-dl/CMakeListsOld.txt"
+        echo "idf_build_get_property(target IDF_TARGET)" > "$AR_COMPS/esp-dl/CMakeLists.txt"
+        echo "if(NOT \${IDF_TARGET} STREQUAL \"esp32c6\" AND NOT \${IDF_TARGET} STREQUAL \"esp32h2\")" >> "$AR_COMPS/esp-dl/CMakeLists.txt"
+        cat "$AR_COMPS/esp-dl/CMakeListsOld.txt" >> "$AR_COMPS/esp-dl/CMakeLists.txt"
+        echo "endif()" >> "$AR_COMPS/esp-dl/CMakeLists.txt"
+        rm -rf "$AR_COMPS/esp-dl/CMakeListsOld.txt"
 else
-	git -C "$AR_COMPS/esp-dl" fetch && \
-	git -C "$AR_COMPS/esp-dl" pull --ff-only
+        git -C "$AR_COMPS/esp-dl" fetch && \
+        git -C "$AR_COMPS/esp-dl" pull --ff-only
 fi
 if [ $? -ne 0 ]; then exit 1; fi
 #this is a temp measure to fix build issue
 if [ -f "$AR_COMPS/esp-dl/idf_component.yml" ]; then
-	rm -rf "$AR_COMPS/esp-dl/idf_component.yml"
+        rm -rf "$AR_COMPS/esp-dl/idf_component.yml"
 fi
 
 #
 # CLONE/UPDATE ESP-SR
 #
-echo "Updating ESP-SR..."
-if [ ! -d "$AR_COMPS/esp-sr" ]; then
-	git clone $SR_REPO_URL "$AR_COMPS/esp-sr"
-else
-	git -C "$AR_COMPS/esp-sr" fetch && \
-	git -C "$AR_COMPS/esp-sr" pull --ff-only
-fi
-if [ $? -ne 0 ]; then exit 1; fi
+#echo "Updating ESP-SR..."
+#if [ ! -d "$AR_COMPS/esp-sr" ]; then
+#       git clone $SR_REPO_URL "$AR_COMPS/esp-sr"
+#else
+#       git -C "$AR_COMPS/esp-sr" fetch && \
+#       git -C "$AR_COMPS/esp-sr" pull --ff-only
+#fi
+#if [ $? -ne 0 ]; then exit 1; fi
 
 #
 # CLONE/UPDATE ESP-RAINMAKER
 #
-echo "Updating ESP-RainMaker..."
-if [ ! -d "$AR_COMPS/esp-rainmaker" ]; then
-    git clone $RMAKER_REPO_URL "$AR_COMPS/esp-rainmaker" && \
-	git -C "$AR_COMPS/esp-rainmaker" reset --hard d8e93454f495bd8a414829ec5e86842b373ff555 && \
-    git -C "$AR_COMPS/esp-rainmaker" submodule update --init --recursive
+#echo "Updating ESP-RainMaker..."
+#if [ ! -d "$AR_COMPS/esp-rainmaker" ]; then
+#    git clone $RMAKER_REPO_URL "$AR_COMPS/esp-rainmaker" && \
+#       git -C "$AR_COMPS/esp-rainmaker" reset --hard d8e93454f495bd8a414829ec5e86842b373ff555 && \
+#    git -C "$AR_COMPS/esp-rainmaker" submodule update --init --recursive
 # else
-# 	git -C "$AR_COMPS/esp-rainmaker" fetch && \
-# 	git -C "$AR_COMPS/esp-rainmaker" pull --ff-only && \
+#       git -C "$AR_COMPS/esp-rainmaker" fetch && \
+#       git -C "$AR_COMPS/esp-rainmaker" pull --ff-only && \
 #     git -C "$AR_COMPS/esp-rainmaker" submodule update --init --recursive
-fi
-if [ $? -ne 0 ]; then exit 1; fi
+#fi
+#if [ $? -ne 0 ]; then exit 1; fi
 
 #this is a temp measure to fix build issue
-if [ -f "$AR_COMPS/esp-rainmaker/components/esp-insights/components/esp_insights/scripts/get_projbuild_gitconfig.py" ] && [ `cat "$AR_COMPS/esp-rainmaker/components/esp-insights/components/esp_insights/scripts/get_projbuild_gitconfig.py" | grep esp32c6 | wc -l` == "0" ]; then
-	echo "Overwriting 'get_projbuild_gitconfig.py'"
-	cp -f "tools/get_projbuild_gitconfig.py" "$AR_COMPS/esp-rainmaker/components/esp-insights/components/esp_insights/scripts/get_projbuild_gitconfig.py"
-fi
+#if [ -f "$AR_COMPS/esp-rainmaker/components/esp-insights/components/esp_insights/scripts/get_projbuild_gitconfig.py" ] && [ `cat "$AR_COMPS/esp-rainmaker/components/esp-insights/components/esp_insights/scripts/get_projbuild_gitconfig.py" | grep esp32c6 | wc -l` == "0" ]; then
+#       echo "Overwriting 'get_projbuild_gitconfig.py'"
+#       cp -f "tools/get_projbuild_gitconfig.py" "$AR_COMPS/esp-rainmaker/components/esp-insights/components/esp_insights/scripts/get_projbuild_gitconfig.py"
+#fi
 
 #
 # CLONE/UPDATE ESP-LITTLEFS
 #
-echo "Updating ESP-LITTLEFS..."
-if [ ! -d "$AR_COMPS/esp_littlefs" ]; then
-	git clone $LITTLEFS_REPO_URL "$AR_COMPS/esp_littlefs" && \
-    git -C "$AR_COMPS/esp_littlefs" submodule update --init --recursive
-else
-	git -C "$AR_COMPS/esp_littlefs" fetch && \
-	git -C "$AR_COMPS/esp_littlefs" pull --ff-only && \
-    git -C "$AR_COMPS/esp_littlefs" submodule update --init --recursive
-fi
-if [ $? -ne 0 ]; then exit 1; fi
+#echo "Updating ESP-LITTLEFS..."
+#if [ ! -d "$AR_COMPS/esp_littlefs" ]; then
+#       git clone $LITTLEFS_REPO_URL "$AR_COMPS/esp_littlefs" && \
+#    git -C "$AR_COMPS/esp_littlefs" submodule update --init --recursive
+#else
+#       git -C "$AR_COMPS/esp_littlefs" fetch && \
+#       git -C "$AR_COMPS/esp_littlefs" pull --ff-only && \
+#    git -C "$AR_COMPS/esp_littlefs" submodule update --init --recursive
+#fi
+#if [ $? -ne 0 ]; then exit 1; fi
 
 #
 # CLONE/UPDATE TINYUSB
 #
 echo "Updating TinyUSB..."
 if [ ! -d "$AR_COMPS/arduino_tinyusb/tinyusb" ]; then
-	git clone $TINYUSB_REPO_URL "$AR_COMPS/arduino_tinyusb/tinyusb"
+        git clone $TINYUSB_REPO_URL "$AR_COMPS/arduino_tinyusb/tinyusb"
 else
-	git -C "$AR_COMPS/arduino_tinyusb/tinyusb" fetch && \
-	git -C "$AR_COMPS/arduino_tinyusb/tinyusb" pull --ff-only
+        git -C "$AR_COMPS/arduino_tinyusb/tinyusb" fetch && \
+        git -C "$AR_COMPS/arduino_tinyusb/tinyusb" pull --ff-only
 fi
 if [ $? -ne 0 ]; then exit 1; fi
 
 #
 # CLONE/UPDATE TFLITE MICRO
 #
-echo "Updating TFLite Micro..."
-if [ ! -d "$AR_COMPS/tflite-micro" ]; then
-	git clone $TFLITE_REPO_URL "$AR_COMPS/tflite-micro"
-	git -C "$AR_COMPS/tflite-micro" submodule update --init --recursive
-else
-	git -C "$AR_COMPS/tflite-micro" fetch && \
-	git -C "$AR_COMPS/tflite-micro" pull --ff-only
-	git -C "$AR_COMPS/tflite-micro" submodule update --init --recursive
-fi
-if [ $? -ne 0 ]; then exit 1; fi
+#echo "Updating TFLite Micro..."
+#if [ ! -d "$AR_COMPS/tflite-micro" ]; then
+#       git clone $TFLITE_REPO_URL "$AR_COMPS/tflite-micro"
+#       git -C "$AR_COMPS/tflite-micro" submodule update --init --recursive
+#else
+#       git -C "$AR_COMPS/tflite-micro" fetch && \
+#       git -C "$AR_COMPS/tflite-micro" pull --ff-only
+#       git -C "$AR_COMPS/tflite-micro" submodule update --init --recursive
+#fi
+#if [ $? -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
This PR makes 2 main changes:
1- Fixes CMakeFiles and the build.sh + copy-libs.sh to work with WSL Ubuntu
2- Removes RainMaker and other git-cloned component in order to use them from the Managed Components Registry.

This change demands that Arduino Repository also change in orde to reflect the use of Managed Components.
https://github.com/espressif/arduino-esp32/pull/8842