### PR TITLE
Copy Zigbee + Zboss libraries

### DIFF
--- a/tools/copy-libs.sh
+++ b/tools/copy-libs.sh
@@ -485,6 +485,15 @@ if [ -f "build/srmodels/srmodels.bin" ]; then
 	cp -f "partitions.csv" "$AR_SDK/esp_sr/"
 fi
 
+# copy zigbee + zboss lib
+if [ -d "managed_components/espressif__esp-zigbee-lib/lib/$IDF_TARGET/" ]; then
+	cp -r "managed_components/espressif__esp-zigbee-lib/lib/$IDF_TARGET"/* "$AR_SDK/lib/"
+fi
+
+if [ -d "managed_components/espressif__esp-zboss-lib/lib/$IDF_TARGET/" ]; then
+	cp -r "managed_components/espressif__esp-zboss-lib/lib/$IDF_TARGET"/* "$AR_SDK/lib/"
+fi
+
 # sdkconfig
 cp -f "sdkconfig" "$AR_SDK/sdkconfig"
 


### PR DESCRIPTION
Added manual copy of Zigbee and Zboss libraries for each SoC as automatic build by enabling in SDK config is not possible to include all zigbee modes (libraries).

Follow up PR (WIP) in Arduino-esp32 repository to add Zigbee and Zboss as managed components.