### PR TITLE
esp-dl as managed component

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,16 +1,15 @@
 dependencies:
   # Required IDF version
   idf: ">=5.1"
-    require: public
   espressif/esp32-camera:
-    version: "*"
+    version: "master"
     git: https://github.com/espressif/esp32-camera.git
     require: public
   espressif/esp-tflite-micro:
     version: ">=1.2.0"
     require: public
   espressif/esp-dl:
-    version: "*"
+    version: "master"
     git: https://github.com/espressif/esp-dl.git
     require: public
     rules:

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,6 +1,7 @@
 dependencies:
   # Required IDF version
   idf: ">=5.1"
+    require: public
   espressif/esp32-camera:
     version: "*"
     git: https://github.com/espressif/esp32-camera.git
@@ -9,8 +10,8 @@ dependencies:
     version: ">=1.2.0"
     require: public
   espressif/esp-dl:
-    version: ">=2.0.0"
-    path: ../components/esp-dl
+    version: "*"
+    git: https://github.com/espressif/esp-dl.git
     require: public
     rules:
       - if: "target in [esp32s3]"

--- a/tools/update-components.sh
+++ b/tools/update-components.sh
@@ -25,25 +25,25 @@ TFLITE_REPO_URL="https://github.com/espressif/tflite-micro-esp-examples.git"
 #
 # CLONE/UPDATE ESP-DL
 #
-echo "Updating ESP-DL..."
-if [ ! -d "$AR_COMPS/esp-dl" ]; then
-        git clone $DL_REPO_URL "$AR_COMPS/esp-dl"
+#echo "Updating ESP-DL..."
+#if [ ! -d "$AR_COMPS/esp-dl" ]; then
+#        git clone $DL_REPO_URL "$AR_COMPS/esp-dl"
         #this is a temp measure to fix build issue
-        mv "$AR_COMPS/esp-dl/CMakeLists.txt" "$AR_COMPS/esp-dl/CMakeListsOld.txt"
-        echo "idf_build_get_property(target IDF_TARGET)" > "$AR_COMPS/esp-dl/CMakeLists.txt"
-        echo "if(NOT \${IDF_TARGET} STREQUAL \"esp32c6\" AND NOT \${IDF_TARGET} STREQUAL \"esp32h2\")" >> "$AR_COMPS/esp-dl/CMakeLists.txt"
-        cat "$AR_COMPS/esp-dl/CMakeListsOld.txt" >> "$AR_COMPS/esp-dl/CMakeLists.txt"
-        echo "endif()" >> "$AR_COMPS/esp-dl/CMakeLists.txt"
-        rm -rf "$AR_COMPS/esp-dl/CMakeListsOld.txt"
-else
-        git -C "$AR_COMPS/esp-dl" fetch && \
-        git -C "$AR_COMPS/esp-dl" pull --ff-only
-fi
-if [ $? -ne 0 ]; then exit 1; fi
+#        mv "$AR_COMPS/esp-dl/CMakeLists.txt" "$AR_COMPS/esp-dl/CMakeListsOld.txt"
+#        echo "idf_build_get_property(target IDF_TARGET)" > "$AR_COMPS/esp-dl/CMakeLists.txt"
+#        echo "if(NOT \${IDF_TARGET} STREQUAL \"esp32c6\" AND NOT \${IDF_TARGET} STREQUAL \"esp32h2\")" >> "$AR_COMPS/esp-dl/CMakeLists.txt"
+#        cat "$AR_COMPS/esp-dl/CMakeListsOld.txt" >> "$AR_COMPS/esp-dl/CMakeLists.txt"
+#        echo "endif()" >> "$AR_COMPS/esp-dl/CMakeLists.txt"
+#        rm -rf "$AR_COMPS/esp-dl/CMakeListsOld.txt"
+#else
+#        git -C "$AR_COMPS/esp-dl" fetch && \
+#        git -C "$AR_COMPS/esp-dl" pull --ff-only
+#fi
+#if [ $? -ne 0 ]; then exit 1; fi
 #this is a temp measure to fix build issue
-if [ -f "$AR_COMPS/esp-dl/idf_component.yml" ]; then
-        rm -rf "$AR_COMPS/esp-dl/idf_component.yml"
-fi
+#if [ -f "$AR_COMPS/esp-dl/idf_component.yml" ]; then
+#        rm -rf "$AR_COMPS/esp-dl/idf_component.yml"
+#fi
 
 #
 # CLONE/UPDATE ESP-SR


### PR DESCRIPTION
Removes git clone esp-dl from update-component.sh
Moves esp-dl to managed components for Lib Builder layer only - S3 only - from master GH