### PR TITLE
Replace "arch" with "uname -m"

### DIFF
--- a/tools/config.sh
+++ b/tools/config.sh
@@ -58,7 +58,7 @@ if [ -d "$IDF_PATH" ]; then
 fi
 
 function get_os(){
-    OSBITS=`arch`
+    OSBITS=`uname -m`
     if [[ "$OSTYPE" == "linux"* ]]; then
         if [[ "$OSBITS" == "i686" ]]; then
             echo "linux32"


### PR DESCRIPTION
The `arch` alias/command is not available on many distros. By replacing it with `uname -m` we can make the lib-builder more distro agnostic and enable compilation in distros like Arch.

https://man7.org/linux/man-pages/man1/arch.1.html