### PR TITLE
add zigbee libs for Platformio

### DIFF
--- a/configs/pio_start.txt
+++ b/configs/pio_start.txt
@@ -37,4 +37,39 @@ FRAMEWORK_SDK_DIR = env.PioPlatform().get_package_dir(
 
 board_config = env.BoardConfig()
 
+flatten_cppdefines = env.Flatten(env['CPPDEFINES'])
+
+#
+# zigbee libs
+#
+if "ZIGBEE_MODE_ZCZR" in flatten_cppdefines:
+    env.Append(
+        LIBS=[
+            "-lesp_zb_api_zczr",
+            "-lesp_zb_cli_command",
+            "-lzboss_stack.zczr.trace",
+            "-lzboss_stack.zczr",
+            "-lzboss_port"
+        ]
+    )
+if "ZIGBEE_MODE_ED" in flatten_cppdefines:
+    env.Append(
+        LIBS=[
+            "-lesp_zb_api_ed",
+            "-lesp_zb_cli_command",
+            "-lzboss_stack.ed.trace",
+            "-lzboss_stack.ed",
+            "-lzboss_port"
+        ]
+    )
+if "ZIGBEE_MODE_RCP" in flatten_cppdefines:
+    env.Append(
+        LIBS=[
+            "-lesp_zb_api_rcp",
+            "-lesp_zb_cli_command",
+            "-lzboss_stack.rcp",
+            "-lzboss_port"
+        ]
+    )
+
 env.Append(


### PR DESCRIPTION
@me-no-dev 
currently zigbee libs are not added in Platformio build process.

The needed libs are added with adding the corresponding define in Platformio `build_flags`
Something like:

```
build_flags  =  -DZIGBEE_MODE_ZCZR
```
for Zigbee Coordinator. 