### PR TITLE
fix(install): Fetch before checkout to avoid errors

### DIFF
--- a/tools/install-arduino.sh
+++ b/tools/install-arduino.sh
@@ -41,8 +41,8 @@ fi
 
 if [ "$AR_BRANCH" ]; then
 	echo "AR_BRANCH='$AR_BRANCH'"
+	git -C "$AR_COMPS/arduino" fetch --all && \
 	git -C "$AR_COMPS/arduino" checkout "$AR_BRANCH" && \
-	git -C "$AR_COMPS/arduino" fetch && \
 	git -C "$AR_COMPS/arduino" pull --ff-only
 fi
 if [ $? -ne 0 ]; then exit 1; fi

--- a/tools/install-esp-idf.sh
+++ b/tools/install-esp-idf.sh
@@ -17,6 +17,8 @@ if [ ! -d "$IDF_PATH" ]; then
 	idf_was_installed="1"
 fi
 
+git -C "$IDF_PATH" fetch --all --tags
+
 if [ "$IDF_TAG" ]; then
     git -C "$IDF_PATH" checkout "tags/$IDF_TAG"
     idf_was_installed="1"


### PR DESCRIPTION
Trying to checkout to a branch that does not exist yet fails.

Moved fetch to before checkout to avoid this situation. Also added `--all` flag to get the correct branches no matter how the remotes are set up.