### PR TITLE
feat(matter): removes -DESP32=ESP32

### DIFF
--- a/tools/copy-libs.sh
+++ b/tools/copy-libs.sh
@@ -102,7 +102,7 @@ for item in "${@:2:${#@}-5}"; do
 			INCLUDES+="$item "
 		fi
 	elif [ "$prefix" = "-D" ]; then
-		if [[ "${item:2:7}" != "ARDUINO" ]] && [[ "$item" != "-DESP32" ]]; then #skip ARDUINO defines
+		if [[ "${item:2:7}" != "ARDUINO" ]] && [[ "$item" != "-DESP32=ESP32" ]]; then #skip ARDUINO defines
 			DEFINES+="$item "
 		fi
 	elif [ "$prefix" = "-O" ]; then


### PR DESCRIPTION
## Description

removes -DESP32=ESP32 from flags/defines for V5.1


## Related

None

## Testing

CI

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
