### PR TITLE
fix(config): Add fallback value to AR_USER

### DIFF
--- a/tools/config.sh
+++ b/tools/config.sh
@@ -25,7 +25,7 @@ if [ -z $IDF_TARGET ]; then
 fi
 
 # Owner of the target ESP32 Arduino repository
-AR_USER="$GITHUB_REPOSITORY_OWNER"
+AR_USER="${GITHUB_REPOSITORY_OWNER:-espressif}"
 
 # The full name of the repository
 AR_REPO="$AR_USER/arduino-esp32"


### PR DESCRIPTION
## Description

Add missing fallback value to `AR_USER`. This is required when running locally.

## Related

Closes #247

## Testing

Locally
