### PR TITLE
Update defconfig.esp32c6 and defconfig.esp32h2 to disable OpenThread DNS64

### DIFF
--- a/configs/defconfig.esp32c6
+++ b/configs/defconfig.esp32c6
@@ -15,7 +15,11 @@ CONFIG_OPENTHREAD_ENABLED=y
 # Border Router disabled
 # CONFIG_OPENTHREAD_BORDER_ROUTER=y
 # CONFIG_OPENTHREAD_RADIO_SPINEL_UART=y
+
+# DNS64 and NAT64 will be disabled for a while
+# OT IDF issue https://github.com/espressif/esp-idf/issues/15069
 CONFIG_OPENTHREAD_DNS64_CLIENT=y
+
 # Radio for RPC
 # CONFIG_OPENTHREAD_RADIO=y 
 # CONFIG_OPENTHREAD_RADIO_NATIVE=y

--- a/configs/defconfig.esp32c6
+++ b/configs/defconfig.esp32c6
@@ -18,7 +18,7 @@ CONFIG_OPENTHREAD_ENABLED=y
 
 # DNS64 and NAT64 will be disabled for a while
 # OT IDF issue https://github.com/espressif/esp-idf/issues/15069
-CONFIG_OPENTHREAD_DNS64_CLIENT=y
+# CONFIG_OPENTHREAD_DNS64_CLIENT=y
 
 # Radio for RPC
 # CONFIG_OPENTHREAD_RADIO=y 

--- a/configs/defconfig.esp32h2
+++ b/configs/defconfig.esp32h2
@@ -14,7 +14,7 @@ CONFIG_OPENTHREAD_ENABLED=y
 
 # DNS64 and NAT64 will be disabled for a while
 # OT IDF issue https://github.com/espressif/esp-idf/issues/15069
-CONFIG_OPENTHREAD_DNS64_CLIENT=y
+# CONFIG_OPENTHREAD_DNS64_CLIENT=y
 
 # Radio for RPC
 # CONFIG_OPENTHREAD_RADIO=y 

--- a/configs/defconfig.esp32h2
+++ b/configs/defconfig.esp32h2
@@ -11,7 +11,11 @@ CONFIG_OPENTHREAD_ENABLED=y
 # Border Router disabled
 # CONFIG_OPENTHREAD_BORDER_ROUTER=y
 # CONFIG_OPENTHREAD_RADIO_SPINEL_UART=y
+
+# DNS64 and NAT64 will be disabled for a while
+# OT IDF issue https://github.com/espressif/esp-idf/issues/15069
 CONFIG_OPENTHREAD_DNS64_CLIENT=y
+
 # Radio for RPC
 # CONFIG_OPENTHREAD_RADIO=y 
 # CONFIG_OPENTHREAD_RADIO_NATIVE=y


### PR DESCRIPTION
## Description
Disable OpenThread DNS64 Client for the ESP32-C6 and ESP32-H2.
There is a conflic after an ESP-IDF change to OpenThread.


## Related
https://github.com/espressif/esp-idf/issues/15069

## Testing
Using artifacts based on issue https://github.com/espressif/arduino-esp32/issues/10754