### PR TITLE
fix(zigbee): Exclude correct libs for 1.6.2 version

### DIFF
--- a/tools/copy-libs.sh
+++ b/tools/copy-libs.sh
@@ -95,7 +95,7 @@ fi
 
 if [ -d "managed_components/espressif__esp-zboss-lib/lib/$IDF_TARGET/" ]; then
 	cp -r "managed_components/espressif__esp-zboss-lib/lib/$IDF_TARGET"/* "$AR_SDK/lib/"
-	EXCLUDE_LIBS+="zboss_stack.ed;zboss_port.debug;"
+	EXCLUDE_LIBS+="zboss_stack.ed;zboss_port.native.debug;"
 fi
 
 #collect includes, defines and c-flags


### PR DESCRIPTION
## Description
Update exclude libs for Zigbee targeting 3.2.x release (IDF v5.4)

## Related
https://github.com/espressif/arduino-esp32/pull/10890

## Testing