### PR TITLE
fix S3 RGB LCD Display crashes

### DIFF
--- a/configs/builds.json
+++ b/configs/builds.json
@@ -37,6 +37,12 @@
 			"targets":["esp32s3"]
 		},
 		{
+			"file":"libesp_lcd.a",
+			"src":"build/esp-idf/esp_lcd/libesp_lcd.a",
+			"out":"lib/libesp_lcd.a",
+			"targets":["esp32s3"]
+		},
+		{
 			"file":"sections.ld",
 			"src":"build/esp-idf/esp_system/ld/sections.ld",
 			"out":"ld/sections.ld",


### PR DESCRIPTION
The RGB LCD display driver uses PSRAM and includes the file `#include "esp_psram.h"` 
So it is needed to have the precompiled lib blob `libesp_lcd.a` for every S3 Flash PSRAM variant. 

@me-no-dev 