### PR TITLE
fix(zigbee): Update exclude libs in script

### DIFF
--- a/tools/copy-libs.sh
+++ b/tools/copy-libs.sh
@@ -90,12 +90,12 @@ fi
 # copy zigbee + zboss lib
 if [ -d "managed_components/espressif__esp-zigbee-lib/lib/$IDF_TARGET/" ]; then
 	cp -r "managed_components/espressif__esp-zigbee-lib/lib/$IDF_TARGET"/* "$AR_SDK/lib/"
-	EXCLUDE_LIBS+="esp_zb_api_ed;"
+	EXCLUDE_LIBS+="esp_zb_api.ed;"
 fi
 
 if [ -d "managed_components/espressif__esp-zboss-lib/lib/$IDF_TARGET/" ]; then
 	cp -r "managed_components/espressif__esp-zboss-lib/lib/$IDF_TARGET"/* "$AR_SDK/lib/"
-	EXCLUDE_LIBS+="zboss_stack.ed;zboss_port.native.debug;"
+	EXCLUDE_LIBS+="zboss_stack.ed;zboss_port.native;zboss_port.native.debug;"
 fi
 
 #collect includes, defines and c-flags


### PR DESCRIPTION
## Description
This PR fixes zigbee-sdk libs, that were not excluded properly.

ZIGBEE LIBS:
`esp_zb_api_ed` changed to `esp_zb_api.ed`

ZBOSS LIBS:
added `zboss_port.native`