### PR TITLE
fix(libs): Add also zcrz and remote zb libs to exclude

### DIFF
--- a/tools/copy-libs.sh
+++ b/tools/copy-libs.sh
@@ -90,12 +90,12 @@ fi
 # copy zigbee + zboss lib
 if [ -d "managed_components/espressif__esp-zigbee-lib/lib/$IDF_TARGET/" ]; then
 	cp -r "managed_components/espressif__esp-zigbee-lib/lib/$IDF_TARGET"/* "$AR_SDK/lib/"
-	EXCLUDE_LIBS+="esp_zb_api.ed;"
+	EXCLUDE_LIBS+="esp_zb_api.ed;esp_zb_api.zczr;"
 fi
 
 if [ -d "managed_components/espressif__esp-zboss-lib/lib/$IDF_TARGET/" ]; then
 	cp -r "managed_components/espressif__esp-zboss-lib/lib/$IDF_TARGET"/* "$AR_SDK/lib/"
-	EXCLUDE_LIBS+="zboss_stack.ed;zboss_port.native;zboss_port.native.debug;"
+	EXCLUDE_LIBS+="zboss_stack.ed;zboss_stack.zczr;zboss_port.native;zboss_port.native.debug;zboss_port.remote;zboss_port.remote.debug;"
 fi
 
 #collect includes, defines and c-flags


### PR DESCRIPTION
## Description
As all SOCs now compile with Zigbee enabled, exclude all possible zigbee libs.

## Testing

