### PR TITLE
fixes Matter 1.4 Resolve Include Macro

### DIFF
--- a/tools/copy-libs.sh
+++ b/tools/copy-libs.sh
@@ -525,9 +525,10 @@ for flag_file in "c_flags" "cpp_flags" "S_flags"; do
  	sed 's/\\\"-DCHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib\/address_resolve\/AddressResolve_DefaultImpl.h>\\\"/-DCHIP_HAVE_CONFIG_H/' $FLAGS_DIR/$flag_file > $FLAGS_DIR/$flag_file.temp
 	mv $FLAGS_DIR/$flag_file.temp $FLAGS_DIR/$flag_file
 done
-CHIP_RESOLVE_DIR="$AR_SDK/include/espressif__esp_matter/connectedhomeip/connectedhomeip/src/lib/address_resolve"
-sed 's/CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER/<lib\/address_resolve\/AddressResolve_DefaultImpl.h>/' $CHIP_RESOLVE_DIR/AddressResolve.h > $CHIP_RESOLVE_DIR/AddressResolve_temp.h
-mv $CHIP_RESOLVE_DIR/AddressResolve_temp.h $CHIP_RESOLVE_DIR/AddressResolve.h
+# this is not necessary for Matter 1.4, but it is for Matter 1.3
+#CHIP_RESOLVE_DIR="$AR_SDK/include/espressif__esp_matter/connectedhomeip/connectedhomeip/src/lib/address_resolve"
+#sed 's/CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER/<lib\/address_resolve\/AddressResolve_DefaultImpl.h>/' $CHIP_RESOLVE_DIR/AddressResolve.h > $CHIP_RESOLVE_DIR/AddressResolve_temp.h
+#mv $CHIP_RESOLVE_DIR/AddressResolve_temp.h $CHIP_RESOLVE_DIR/AddressResolve.h
 # End of Matter Library adjustments
 
 # sdkconfig


### PR DESCRIPTION
## Description

There is a Macro for Resolve Include in Matter that has been treated in a different way in Matter 1.4 Managed Component.
This PR solves this issue.

## Related
https://github.com/espressif/esp32-arduino-lib-builder/pull/281

## Testing
CI

## Checklist
