### PR TITLE
ci(workflows): Lock actions to commits and improve readability

### DIFF
--- a/.github/workflows/cron_build.yml
+++ b/.github/workflows/cron_build.yml
@@ -41,7 +41,8 @@ jobs:
       deploy_needed: ${{ steps.check.outputs.deploy_needed }}
       targets_list: ${{ steps.check.outputs.targets_list }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout ${{ inputs.lib_builder_branch }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.lib_builder_branch }}
 
@@ -65,7 +66,8 @@ jobs:
       matrix:
         target: ${{ fromJson(needs.check-if-needed.outputs.targets_list) }}
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout ${{ inputs.lib_builder_branch }}
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ inputs.lib_builder_branch }}
 
@@ -88,13 +90,13 @@ jobs:
 
     - name: Upload build
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: build-${{ env.libs_branch }}-${{ matrix.target }}
         path: build
 
     - name: Upload library files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: libs-${{ env.libs_branch }}-${{ matrix.target }}
         path: dist
@@ -105,7 +107,8 @@ jobs:
     needs: [check-if-needed, build-libs]
     if: needs.check-if-needed.outputs.deploy_needed == '1'
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout ${{ inputs.lib_builder_branch }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.lib_builder_branch }}
 
@@ -115,7 +118,7 @@ jobs:
           echo "libs_branch=${branch//\//_}" >> $GITHUB_ENV
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           path: dist
           pattern: libs-${{ env.libs_branch }}-*
@@ -125,7 +128,7 @@ jobs:
         run: bash ./tools/combine-artifacts.sh
 
       - name: Upload full esp32-arduino-libs archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: esp32-arduino-libs-${{ env.libs_branch }}
           path: dist/esp32-arduino-libs.zip
@@ -154,7 +157,7 @@ jobs:
           bash ./tools/push-to-arduino.sh
 
       - name: Upload package_esp32_index.template.json
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: package-esp32-index-json-${{ env.libs_branch }}
           path: out/package_esp32_index.template.json

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,23 +66,23 @@ jobs:
           echo "URL: $URL"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Login to Docker Hub
         if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU for multiarch builds
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: tools/docker
           push: ${{ github.event_name == 'push' }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Update Docker Hub repository description (master branch)
         if: ${{ github.event_name == 'push' && github.ref_type == 'branch' && github.ref_name == 'master' }}
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,7 +28,8 @@ jobs:
         target: [esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c6, esp32h2, esp32p4]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Install dependencies
       run: bash ./tools/prepare-ci.sh
@@ -38,13 +39,13 @@ jobs:
 
     - name: Upload build
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: build-${{ matrix.target }}
         path: build
 
     - name: Upload archive
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: artifacts-${{ matrix.target }}
         path: dist
@@ -55,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           path: dist
           pattern: artifacts-*
@@ -69,13 +70,13 @@ jobs:
           cp out/package_esp32_index.template.json dist/package_esp32_index.template.json
 
       - name: Upload full esp32-arduino-libs archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: esp32-arduino-libs
           path: dist/esp32-arduino-libs.tar.gz
 
       - name: Upload package_esp32_index.template.json
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: package-esp32-index-json
           path: dist/package_esp32_index.template.json

--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -7,25 +7,30 @@ jobs:
     name: Dispatch Event
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
+
     - name: Install dependencies
       run: bash ./tools/prepare-ci.sh
+
     - name: Handle Event
       env:
         GITHUB_TOKEN: ${{ secrets.PUSH_TOKEN }}
         GIT_AUTHOR_EMAIL: ${{ secrets.PUSH_EMAIL }}
         GIT_COMMITTER_EMAIL: ${{ secrets.PUSH_EMAIL }}
       run: bash ./tools/repository_dispatch.sh
+
     - name: Upload build
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: build
         path: build
+
     - name: Upload archive
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: artifacts
         path: dist


### PR DESCRIPTION
## Description of Change

To avoid supply chain attacks, lock actions used in workflows to commit hash rather than tag.
Also improve readability of files.