### PR TITLE
Update CMakeLists.txt to use gnu++2a instead of 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,4 +39,4 @@ idf_build_set_property(COMPILE_DEFINITIONS "-DESP32_ARDUINO_LIB_BUILDER" APPEND)
 ##################
 ### ESP Matter ###
 ##################
-idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++17;-DCHIP_HAVE_CONFIG_H" APPEND)
+idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++2a;-DCHIP_HAVE_CONFIG_H" APPEND)


### PR DESCRIPTION
## Description
Moving from C++17 to C++2a that works with Matter.

## Related

