### PR TITLE
feat(esp_matter): updates esp_matter component to 1.4.1

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -17,7 +17,7 @@ dependencies:
     rules:
       - if: "target in [esp32s3]"
   espressif/esp_matter:
-    version: "^1.4.1"
+    version: "1.4.1"
     require: public
     rules:
       - if: "target not in [esp32c2, esp32h2, esp32p4]"

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -17,7 +17,7 @@ dependencies:
     rules:
       - if: "target in [esp32s3]"
   espressif/esp_matter:
-    version: "^1.4.0"
+    version: "^1.4.1"
     require: public
     rules:
       - if: "target not in [esp32c2, esp32h2, esp32p4]"


### PR DESCRIPTION
## Description

Updates esp_matter component to 1.4.1 which:

Fixes the `asset()` issue with `-DNDEBUG`
Fixes many warning messages when compiling sketches that use Arduino Matter Library. 


## Related
ESP_MATTER
https://github.com/espressif/arduino-esp32/issues/11166

## Testing

CI + Artifacts