### PR TITLE
fix(logging): Silence stdout from IDF installation

### DIFF
--- a/tools/install-esp-idf.sh
+++ b/tools/install-esp-idf.sh
@@ -33,7 +33,8 @@ fi
 
 if [ ! -x $idf_was_installed ] || [ ! -x $commit_predefined ]; then
 	git -C $IDF_PATH submodule update --init --recursive
-	$IDF_PATH/install.sh
+	echo "Installing ESP-IDF..."
+	$IDF_PATH/install.sh > /dev/null
 	export IDF_COMMIT=$(git -C "$IDF_PATH" rev-parse --short HEAD)
 	export IDF_BRANCH=$(git -C "$IDF_PATH" symbolic-ref --short HEAD || git -C "$IDF_PATH" tag --points-at HEAD)
 


### PR DESCRIPTION
ESP-IDF installation process generates tens of thousands of carriage returns `\r` that are printed as new lines, making the CI log very hard to navigate.

This pull request includes a small change to the `tools/install-esp-idf.sh` script. The change improves the user experience by adding a message to indicate that the ESP-IDF installation process has started and suppresses the installation script's output. Error messages should not be affected.

Impact can be checked here:

https://github.com/espressif/esp32-arduino-lib-builder/actions/runs/15450574032/job/43491389484?pr=300#step:4:116