### PR TITLE
Feat(matter): enable Matter for the C5

### DIFF
--- a/configs/defconfig.esp32c5
+++ b/configs/defconfig.esp32c5
@@ -52,11 +52,11 @@ CONFIG_OPENTHREAD_NETWORK_PSKC="104810e2315100afd6bc9215a6bfac53"
 
 # ESP32-C5 fails when ESP Matter 1.4.1 is used. Try this latter with some other IDF 5.5 commit
 # Matter settings: WiFi and OpenThread + CHIPoBLE
-# CONFIG_ENABLE_CHIPOBLE=y
-# CONFIG_ENABLE_MATTER_OVER_THREAD=y
+CONFIG_ENABLE_CHIPOBLE=y
+CONFIG_ENABLE_MATTER_OVER_THREAD=y
 # Set endpoint id for Thread and Wi-Fi, depending on the secondary network interface endpoint id.
-# CONFIG_THREAD_NETWORK_ENDPOINT_ID=2
-# CONFIG_WIFI_NETWORK_ENDPOINT_ID=0
+CONFIG_THREAD_NETWORK_ENDPOINT_ID=2
+CONFIG_WIFI_NETWORK_ENDPOINT_ID=0
 
 #
 # Zigbee

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -20,4 +20,4 @@ dependencies:
     version: "1.4.1"
     require: public
     rules:
-      - if: "target not in [esp32c2, esp32c5, esp32p4]"
+      - if: "target not in [esp32c2, esp32p4]"


### PR DESCRIPTION
## Description

Enables Matter for the ESP32-C5 based on libraries generted for https://github.com/espressif/arduino-esp32/pull/11531


## Related
https://github.com/espressif/arduino-esp32/pull/11531

## Testing

CI Artifacts