### PR TITLE
feat(matter): matter with thread + ble works fine

### DIFF
--- a/configs/defconfig.esp32c5
+++ b/configs/defconfig.esp32c5
@@ -50,13 +50,12 @@ CONFIG_OPENTHREAD_NETWORK_MASTERKEY="00112233445566778899aabbccddeeff"
 CONFIG_OPENTHREAD_NETWORK_PSKC="104810e2315100afd6bc9215a6bfac53"
 # end of OpenThread
 
-# ESP32-C5 fails when ESP Matter 1.4.1 is used. Try this latter with some other IDF 5.5 commit
-# Matter settings: WiFi and OpenThread + CHIPoBLE
+# Matter settings: OpenThread + CHIPoBLE
 CONFIG_ENABLE_CHIPOBLE=y
 CONFIG_ENABLE_MATTER_OVER_THREAD=y
-# Set endpoint id for Thread and Wi-Fi, depending on the secondary network interface endpoint id.
-CONFIG_THREAD_NETWORK_ENDPOINT_ID=2
-CONFIG_WIFI_NETWORK_ENDPOINT_ID=0
+# Disable Matter over WiFi
+CONFIG_ENABLE_WIFI_AP=n
+CONFIG_ENABLE_WIFI_STATION=n
 
 #
 # Zigbee


### PR DESCRIPTION
## Description
ESP32-C5 has few SRAM available.
Matter consumes a lot of SRAM with its static variable declarations and object constructors.
After testing many combinations, the only way to get esp32c5 working with Arduino and Matter Library is by only using it with OpenThread and BLE commissioning.

This PR sets this configuration.

## Related
None

## Testing
CI Artifacts