### PR TITLE
Enable srmodel export for ESP32-P4

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -226,7 +226,7 @@ for target_json in `jq -c '.targets[]' configs/builds.json`; do
     idf.py -DIDF_TARGET="$target" -DSDKCONFIG_DEFAULTS="$idf_libs_configs" idf-libs
     if [ $? -ne 0 ]; then exit 1; fi
 
-    if [ "$target" == "esp32s3" ]; then
+    if [ "$target" == "esp32s3" ] || [ "$target" == "esp32p4" ]; then
         idf.py -DIDF_TARGET="$target" -DSDKCONFIG_DEFAULTS="$idf_libs_configs" srmodels_bin
         if [ $? -ne 0 ]; then exit 1; fi
         AR_SDK="$AR_TOOLS/esp32-arduino-libs/$target"

--- a/configs/builds.json
+++ b/configs/builds.json
@@ -60,7 +60,7 @@
 		},
 		{
 			"target": "esp32p4",
-			"features":["qio_ram"],
+			"features":["qio_ram","esp_sr"],
 			"idf_libs":["qio","80m_200m"],
 			"bootloaders":[
 				["qio","80m_200m"],


### PR DESCRIPTION
This pull request adds support for the `esp_sr` feature to the `esp32p4` build target and ensures that the `srmodels_bin` build step runs for both `esp32s3` and `esp32p4` targets. These changes help extend speech recognition capabilities and streamline the build process for new hardware.

Build process updates:
* Modified `build.sh` to run the `srmodels_bin` build step for both `esp32s3` and `esp32p4` targets, ensuring speech recognition models are included for the new hardware.

Feature configuration updates:
* Added the `esp_sr` feature to the `esp32p4` target in `configs/builds.json`, enabling speech recognition support for this platform.

To be merged after https://github.com/espressif/arduino-esp32/pull/11785