### PR TITLE
Compile support for TinyUSB Host

### DIFF
--- a/components/arduino_tinyusb/CMakeLists.txt
+++ b/components/arduino_tinyusb/CMakeLists.txt
@@ -25,10 +25,17 @@ if(CONFIG_TINYUSB_ENABLED)
 
   set(srcs
       # espressif:
-      "${COMPONENT_DIR}/src/dcd_dwc2.c"
+      #"${COMPONENT_DIR}/src/dcd_dwc2.c"
       # tusb:
-      #"${COMPONENT_DIR}/tinyusb/src/portable/synopsys/dwc2/dcd_dwc2.c"
+      "${COMPONENT_DIR}/tinyusb/src/portable/synopsys/dwc2/dcd_dwc2.c"
       "${COMPONENT_DIR}/tinyusb/src/portable/synopsys/dwc2/dwc2_common.c"
+      "${COMPONENT_DIR}/tinyusb/src/portable/synopsys/dwc2/hcd_dwc2.c"
+      # common
+      "${COMPONENT_DIR}/tinyusb/src/tusb.c"
+      "${COMPONENT_DIR}/tinyusb/src/common/tusb_fifo.c"
+      # device
+      "${COMPONENT_DIR}/tinyusb/src/device/usbd_control.c"
+      "${COMPONENT_DIR}/tinyusb/src/device/usbd.c"
       "${COMPONENT_DIR}/tinyusb/src/class/cdc/cdc_device.c"
       "${COMPONENT_DIR}/tinyusb/src/class/hid/hid_device.c"
       "${COMPONENT_DIR}/tinyusb/src/class/midi/midi_device.c"
@@ -38,16 +45,25 @@ if(CONFIG_TINYUSB_ENABLED)
       "${COMPONENT_DIR}/tinyusb/src/class/dfu/dfu_device.c"
       "${COMPONENT_DIR}/tinyusb/src/class/vendor/vendor_device.c"
       "${COMPONENT_DIR}/tinyusb/src/class/net/ncm_device.c"
-      "${COMPONENT_DIR}/tinyusb/src/common/tusb_fifo.c"
-      "${COMPONENT_DIR}/tinyusb/src/device/usbd_control.c"
-      "${COMPONENT_DIR}/tinyusb/src/device/usbd.c"
-      "${COMPONENT_DIR}/tinyusb/src/tusb.c")
+      "${COMPONENT_DIR}/tinyusb/src/class/net/ecm_rndis_device.c"
+      "${COMPONENT_DIR}/tinyusb/src/class/usbtmc/usbtmc_device.c"
+      # host
+      "${COMPONENT_DIR}/tinyusb/src/host/usbh.c"
+      "${COMPONENT_DIR}/tinyusb/src/host/hub.c"
+      "${COMPONENT_DIR}/tinyusb/src/class/cdc/cdc_host.c"
+      "${COMPONENT_DIR}/tinyusb/src/class/hid/hid_host.c"
+      "${COMPONENT_DIR}/tinyusb/src/class/midi/midi_host.c"
+      "${COMPONENT_DIR}/tinyusb/src/class/msc/msc_host.c"
+      "${COMPONENT_DIR}/tinyusb/src/class/vendor/vendor_host.c"
+      )
 
   set(includes_private
       # tusb:
+      #"${COMPONENT_DIR}/tinyusb/lib/networking/"
       "${COMPONENT_DIR}/tinyusb/hw/bsp/"
       "${COMPONENT_DIR}/tinyusb/src/"
       "${COMPONENT_DIR}/tinyusb/src/device"
+      "${COMPONENT_DIR}/tinyusb/src/host"
       "${COMPONENT_DIR}/tinyusb/src/portable/synopsys/dwc2"
       )
 

--- a/components/arduino_tinyusb/include/tusb_config.h
+++ b/components/arduino_tinyusb/include/tusb_config.h
@@ -76,6 +76,10 @@ extern "C" {
 #   define CONFIG_TINYUSB_NCM_ENABLED 0
 #endif
 
+#if CONFIG_TINYUSB_ENABLED
+#	define CFG_TUD_ENABLED 1
+#endif
+
 /*                      */
 /* COMMON CONFIGURATION */
 /*                      */
@@ -84,6 +88,7 @@ extern "C" {
 #endif
 #define CFG_TUSB_RHPORT0_MODE       OPT_MODE_DEVICE
 #define CFG_TUSB_OS                 OPT_OS_FREERTOS
+#define BOARD_TUD_RHPORT			0
 
 /* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
  * Tinyusb use follows macros to declare transferring memory so that they can be put
@@ -97,7 +102,11 @@ extern "C" {
 #endif
 
 #ifndef CFG_TUSB_MEM_ALIGN
+#if CONFIG_IDF_TARGET_ESP32P4
+#   define CFG_TUSB_MEM_ALIGN       TU_ATTR_ALIGNED(64)
+#else
 #   define CFG_TUSB_MEM_ALIGN       TU_ATTR_ALIGNED(4)
+#endif
 #endif
 
 #if CONFIG_IDF_TARGET_ESP32P4
@@ -106,8 +115,10 @@ extern "C" {
 #define CFG_TUD_MAX_SPEED OPT_MODE_FULL_SPEED
 #endif
 
+#define BOARD_TUD_MAX_SPEED			CFG_TUD_MAX_SPEED
+
 /*                      */
-/* DRIVER CONFIGURATION */
+/* DEVICE CONFIGURATION */
 /*                      */
 
 #define CFG_TUD_MAINTASK_SIZE 		4096
@@ -154,6 +165,35 @@ extern "C" {
 // VENDOR FIFO size of TX and RX
 #define CFG_TUD_VENDOR_RX_BUFSIZE 	CONFIG_TINYUSB_VENDOR_RX_BUFSIZE
 #define CFG_TUD_VENDOR_TX_BUFSIZE 	CONFIG_TINYUSB_VENDOR_TX_BUFSIZE
+
+/*                      */
+/*  HOST CONFIGURATION  */
+/*                      */
+
+#define CFG_TUH_ENABLED             CFG_TUD_ENABLED
+#define CFG_TUSB_RHPORT1_MODE       OPT_MODE_HOST
+#define BOARD_TUH_RHPORT            1
+#define BOARD_TUH_MAX_SPEED         CFG_TUD_MAX_SPEED
+#define CFG_TUH_ENUMERATION_BUFSIZE 256
+
+#define CFG_TUH_HUB                 2 // number of supported hubs
+#define CFG_TUH_CDC                 1 // CDC ACM
+#define CFG_TUH_CDC_FTDI            1 // FTDI Serial.  FTDI is not part of CDC class, only to re-use CDC driver API
+#define CFG_TUH_CDC_CP210X          1 // CP210x Serial. CP210X is not part of CDC class, only to re-use CDC driver API
+#define CFG_TUH_CDC_CH34X           1 // CH340 or CH341 Serial. CH34X is not part of CDC class, only to re-use CDC driver API
+#define CFG_TUH_HID                 1 // typical keyboard + mouse device can have 3-4 HID interfaces
+#define CFG_TUH_MSC                 1
+//#define CFG_TUH_VENDOR              3
+
+#define CFG_TUH_DEVICE_MAX          (3*CFG_TUH_HUB + 1)
+
+//------------- HID -------------//
+#define CFG_TUH_HID_EPIN_BUFSIZE    64
+#define CFG_TUH_HID_EPOUT_BUFSIZE   64
+
+//------------- CDC -------------//
+#define CFG_TUH_CDC_LINE_CONTROL_ON_ENUM    0x03
+#define CFG_TUH_CDC_LINE_CODING_ON_ENUM   { 115200, CDC_LINE_CODING_STOP_BITS_1, CDC_LINE_CODING_PARITY_NONE, 8 }
 
 #ifdef __cplusplus
 }

--- a/patches/dwc2_esp32_h.diff
+++ b/patches/dwc2_esp32_h.diff
@@ -1,0 +1,18 @@
+diff --git a/src/portable/synopsys/dwc2/dwc2_esp32.h b/src/portable/synopsys/dwc2/dwc2_esp32.h
+index 49b8c54cb..8b5e99741 100644
+--- a/src/portable/synopsys/dwc2/dwc2_esp32.h
++++ b/src/portable/synopsys/dwc2/dwc2_esp32.h
+@@ -70,11 +70,13 @@ static void dwc2_int_handler_wrap(void* arg) {
+   const tusb_role_t role = (tusb_role_t) tu_u16_high((uint16_t)(uintptr_t)arg);
+ #if CFG_TUD_ENABLED
+   if (role == TUSB_ROLE_DEVICE) {
++    void dcd_int_handler(uint8_t rhport);
+     dcd_int_handler(rhport);
+   }
+ #endif
+ #if CFG_TUH_ENABLED && !CFG_TUH_MAX3421
+   if (role == TUSB_ROLE_HOST) {
++    void hcd_int_handler(uint8_t rhport, bool in_isr);
+     hcd_int_handler(rhport, true);
+   }
+ #endif

--- a/tools/update-components.sh
+++ b/tools/update-components.sh
@@ -14,4 +14,7 @@ else
     git -C "$TINYUSB_REPO_DIR" fetch && \
     git -C "$TINYUSB_REPO_DIR" pull --ff-only
 fi
+cd $TINYUSB_REPO_DIR
+patch -p1 -N -i $AR_PATCHES/dwc2_esp32_h.diff
+cd -
 if [ $? -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
This pull request enhances TinyUSB integration in the Arduino ESP32 project by expanding support for USB host functionality alongside device mode. The changes update build configuration, add host-related source files, and introduce new host-specific settings and code patches to enable and configure the host stack.

**Build system and source file updates:**

* Added host-related source files (e.g., `usbh.c`, `hub.c`, host class drivers) to the `srcs` list in `components/arduino_tinyusb/CMakeLists.txt`, enabling compilation of USB host features. Also updated device and common file inclusion for TinyUSB. [[1]](diffhunk://#diff-65072fee7a818b6a36635fa426449363fa8bc019b520ffe351d1de093d61e0cbL28-R38) [[2]](diffhunk://#diff-65072fee7a818b6a36635fa426449363fa8bc019b520ffe351d1de093d61e0cbL41-R66)

**Configuration and settings:**

* Introduced host configuration macros in `tusb_config.h`, such as `CFG_TUH_ENABLED`, `CFG_TUSB_RHPORT1_MODE`, and buffer/device limits for host mode. Also added board-level defines for host port and speed.
* Defined `CFG_TUD_ENABLED` when `CONFIG_TINYUSB_ENABLED` is set, and added board-level macros for device port and speed. Improved memory alignment handling for ESP32P4 targets. [[1]](diffhunk://#diff-62fc42f854930ba1a2e8db9858cf5ec8f5cdabab068b48f8a43d14d50b1c4507R79-R82) [[2]](diffhunk://#diff-62fc42f854930ba1a2e8db9858cf5ec8f5cdabab068b48f8a43d14d50b1c4507R91) [[3]](diffhunk://#diff-62fc42f854930ba1a2e8db9858cf5ec8f5cdabab068b48f8a43d14d50b1c4507R105-R121)

**Code patching for host support:**

* Applied a patch (`dwc2_esp32_h.diff`) to the TinyUSB source, updating interrupt handler logic to call both device and host interrupt handlers as appropriate. [[1]](diffhunk://#diff-b03c9ce8b41e3981eb99c9dc8664be77fabf0e583b497bf6e5940591f340bd06R1-R18) [[2]](diffhunk://#diff-aa268b27eb43b56907cc25b9daff20408da6cd997aeb317263a53200183d0984R17-R19)