### PR TITLE
Add espressif/lan867x driver

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -21,3 +21,7 @@ dependencies:
     require: public
     rules:
       - if: "target not in [esp32c2, esp32p4]"
+  espressif/lan867x:
+    version: "^2.0.0"
+    rules:
+      - if: "target in [esp32, esp32p4]"


### PR DESCRIPTION
## Description

To be able to support Arduino development on the [Silicognition ManT1S](https://www.crowdsupply.com/silicognition/mant1s) board, support for the `espressif/lan867x` driver first needs to be added to the Arduino Library.
Once the driver is available, support for the ManT1S will be added to the ESP32 Arduino Core.

This PR adds generic LAN867x driver support for chips that support the RMII PHY interface (ESP32 and ESP32P4).
It only touches `main/idf_component.yml` to pull in this component from the ESP Component Registry.

## Related

Support LAN867x driver already supported in ESP-IDF through the [ESP Component Registry](https://components.espressif.com/components/espressif/lan867x/versions/2.0.0/readme).

## Testing

It was checked that `espressif/lan867x` lib and include was (only) added to `esp32` and `esp32p4` output directories.

Local build of `esp32-arduino-lib-builder` with this addition was used to build Arduino firmware on local ESP32 Arduino Core patched to support the ManT1S board.  Building succeeds and runs ETH_LAN8720 example unmodified when Silicognition ManT1S board is selected (ETH_PHY_MDC is defined for the board in the `pins_arduino.h` so the PHY config in the sketch is ignored and the one defined for the board is used).

The code runs and produces the expected output when connected to a ManT1S-Bridge to provide Internet access:

```
ETH Got IP
*eth0: <UP,10M,ADDR:0x0> (DHCPC,GARP,IP_MOD) PRIO: 50
      ether F0:24:F9:9E:1D:5B
      inet 192.168.1.190 netmask 255.255.255.0 broadcast 192.168.1.255
      gateway 192.168.1.1 dns 192.168.1.1


connecting to google.com
HTTP/1.1 301 Moved Permanently
Location: http://www.google.com/
Content-Type: text/html; charset=UTF-8
Content-Security-Policy-Report-Only: object-src 'none';base-uri 'self';script-src 'nonce-aOCnSAoP8-PrQ5wC-FdnLQ' 'strict-dynamic' 'report-sample' 'unsafe-eval' 'unsafe-inline' https: http:;report-uri https://csp.withgoogle.com/csp/gws/other-hp
Date: Mon, 08 Sep 2025 22:21:03 GMT
Expires: Wed, 08 Oct 2025 22:21:03 GMT
Cache-Control: public, max-age=2592000
Server: gws
Content-Length: 219
X-XSS-Protection: 0
X-Frame-Options: SAMEORIGIN

<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com/">here</A>.
</BODY></HTML>
closing connection
```
 
## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
