### PR TITLE
Add script to build ESP-Hosted slave firmwares

### DIFF
--- a/tools/build-hosted.sh
+++ b/tools/build-hosted.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+CCACHE_ENABLE=1
+
+export IDF_CCACHE_ENABLE=$CCACHE_ENABLE
+source ./tools/config.sh
+
+SLAVE_DIR="$AR_MANAGED_COMPS/espressif__esp_hosted/slave"
+
+if [ ! -d "$SLAVE_DIR" ]; then
+	echo "ESP-Hosted component not found!"
+	exit 1
+fi
+
+VERSION_FILE="$SLAVE_DIR/main/esp_hosted_coprocessor_fw_ver.h"
+
+if [ ! -f "$VERSION_FILE" ]; then
+    echo "Error: File $VERSION_FILE not found!"
+    exit 1
+fi
+
+MAJOR=$(grep "PROJECT_VERSION_MAJOR_1" "$VERSION_FILE" | sed 's/.*PROJECT_VERSION_MAJOR_1 \([0-9]*\).*/\1/')
+MINOR=$(grep "PROJECT_VERSION_MINOR_1" "$VERSION_FILE" | sed 's/.*PROJECT_VERSION_MINOR_1 \([0-9]*\).*/\1/')
+PATCH=$(grep "PROJECT_VERSION_PATCH_1" "$VERSION_FILE" | sed 's/.*PROJECT_VERSION_PATCH_1 \([0-9]*\).*/\1/')
+
+if [ -z "$MAJOR" ] || [ -z "$MINOR" ] || [ -z "$PATCH" ]; then
+    echo "Error: Could not extract all version infos!"
+    echo "MAJOR: '$MAJOR', MINOR: '$MINOR', PATCH: '$PATCH'"
+    exit 1
+fi
+
+VERSION="$MAJOR.$MINOR.$PATCH"
+echo "Building ESP-Hosted firmware $VERSION"
+
+cd "$SLAVE_DIR"
+
+OUTPUT_DIR="$AR_TOOLS/esp32-arduino-libs/hosted"
+mkdir -p "$OUTPUT_DIR"
+
+TARGETS=(
+    "esp32c5"
+    "esp32c6"
+)
+
+for target in "${TARGETS[@]}"; do
+    echo "Building for target: $target"
+    idf.py set-target "$target"
+    idf.py clean
+    idf.py build
+    cp "$SLAVE_DIR/build/network_adapter.bin" "$OUTPUT_DIR/$target-v$VERSION.bin"
+    echo "Build completed: $target-v$VERSION.bin"
+done


### PR DESCRIPTION
This pull request adds support for building ESP-Hosted slave firmwares as part of the build process. It introduces a new build type, updates the build script to handle it, and adds a dedicated script for building ESP-Hosted firmwares for specific targets.

**ESP-Hosted build integration:**

* Added a new build type `hosted` to the `build.sh` script, allowing users to trigger ESP-Hosted firmware builds via a command-line flag. [[1]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L34-R34) [[2]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L90-R91)
* When the `hosted` build type is selected, the build system now calls the new `tools/build-hosted.sh` script to handle the ESP-Hosted build process.
* During standard builds, if the target is `esp32p4`, the system will also invoke the ESP-Hosted build script to ensure relevant firmwares are built.

**New ESP-Hosted build script:**

* Introduced `tools/build-hosted.sh`, which locates the ESP-Hosted component, extracts its version information, and builds firmware binaries for the `esp32c5` and `esp32c6` targets. The script outputs the built binaries to a designated directory and provides status messages for each build.