### PR TITLE
Fix: pioarduino linker errors for C6 and C5 zigbee sketches

### DIFF
--- a/configs/pioarduino_start.txt
+++ b/configs/pioarduino_start.txt
@@ -64,7 +64,7 @@ if "ZIGBEE_MODE_ED" in flatten_cppdefines and build_mcu in ["esp32c5", "esp32c6"
             "-lzboss_port.native"
         ]
     )
-if ("ZIGBEE_MODE_ZCZR" in flatten_cppdefines or "ZIGBEE_MODE_ED" in flatten_cppdefines) and build_mcu in ["esp32", "esp32s2", "esp32s3", "esp32c3", "esp32c5", "esp32c6"]:
+if ("ZIGBEE_MODE_ZCZR" in flatten_cppdefines or "ZIGBEE_MODE_ED" in flatten_cppdefines) and build_mcu in ["esp32", "esp32s2", "esp32s3", "esp32c3"]:
     env.Append(
         LIBS=[
             "-libzboss_port.remote"


### PR DESCRIPTION
Remove MCUs with native zigbee support from the list of zigbee remote MCUs.

@me-no-dev Please merge before the next build / release THX!