### PR TITLE
fix(tinyusb): Remove unexisting file form CMakeLists.txt

### DIFF
--- a/components/arduino_tinyusb/CMakeLists.txt
+++ b/components/arduino_tinyusb/CMakeLists.txt
@@ -32,7 +32,6 @@ if(CONFIG_TINYUSB_ENABLED)
       "${COMPONENT_DIR}/tinyusb/src/tusb.c"
       "${COMPONENT_DIR}/tinyusb/src/common/tusb_fifo.c"
       # device
-      "${COMPONENT_DIR}/tinyusb/src/device/usbd_control.c"
       "${COMPONENT_DIR}/tinyusb/src/device/usbd.c"
       "${COMPONENT_DIR}/tinyusb/src/class/cdc/cdc_device.c"
       "${COMPONENT_DIR}/tinyusb/src/class/hid/hid_device.c"


### PR DESCRIPTION
## Description
 [`components/arduino_tinyusb/CMakeLists.txt`](diffhunk://#diff-65072fee7a818b6a36635fa426449363fa8bc019b520ffe351d1de093d61e0cbL35): Removed `usbd_control.c` from the TinyUSB device source files.
## Related
PR in TinySUB repo https://github.com/hathach/tinyusb/pull/3627

## Testing
Tested using the USB-HOST testing sketch