### PR TITLE
fix(docker): Lock Ubuntu image version

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,5 +1,5 @@
 # To Do: Check if it is worth to use espressif/idf as base image (image size will be much bigger)
-FROM ubuntu:latest
+FROM ubuntu:24.04
 
 # switch to root, let the entrypoint drop back to host user
 USER root


### PR DESCRIPTION
## Description

Lock Ubuntu version to avoid build failures in the newest versions