### PR TITLE
feat(tinyusb): Config proper amount of max HID interfaces

### DIFF
--- a/components/arduino_tinyusb/include/tusb_config.h
+++ b/components/arduino_tinyusb/include/tusb_config.h
@@ -206,7 +206,8 @@ extern "C" {
 #define CFG_TUH_CDC_FTDI            1 // FTDI Serial.  FTDI is not part of CDC class, only to re-use CDC driver API
 #define CFG_TUH_CDC_CP210X          1 // CP210x Serial. CP210X is not part of CDC class, only to re-use CDC driver API
 #define CFG_TUH_CDC_CH34X           1 // CH340 or CH341 Serial. CH34X is not part of CDC class, only to re-use CDC driver API
-#define CFG_TUH_HID                 1 // typical keyboard + mouse device can have 3-4 HID interfaces
+/* Max simultaneous HID interfaces (TinyUSB hid_host.c: _hidh_itf[CFG_TUH_HID]). Value 1 allows only one iface stack-wide. */
+#define CFG_TUH_HID                 (3*CFG_TUH_DEVICE_MAX) // typical keyboard + mouse device can have 3-4 HID interfaces
 #define CFG_TUH_MSC                 1
 #define CFG_TUH_MIDI                1 // MIDI host driver; midi_host.c is already compiled, this enables it
 //#define CFG_TUH_VENDOR              3


### PR DESCRIPTION
## Description
This pull request increases the maximum number of simultaneous HID interfaces supported by the TinyUSB host stack. The change updates the `CFG_TUH_HID` definition to allow for more HID devices to be connected at once, scaling with the number of devices supported.

Configuration changes:

* Increased `CFG_TUH_HID` from `1` to `(3*CFG_TUH_DEVICE_MAX)` in `tusb_config.h`, allowing up to three HID interfaces per device, which supports typical use cases like connecting multiple keyboards and mice.

## Testing
Tested Using the USB Host library and multiple USB devices
