### PR TITLE
Feat/arduino matter v1.5 upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,3 +40,14 @@ idf_build_set_property(COMPILE_DEFINITIONS "-DESP32_ARDUINO_LIB_BUILDER" APPEND)
 ### ESP Matter ###
 ##################
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++2a;-DCHIP_HAVE_CONFIG_H" APPEND)
+
+# esp_matter is not pulled in for all targets (see main/idf_component.yml rules).
+idf_build_get_property(build_components BUILD_COMPONENTS)
+if("espressif__esp_matter" IN_LIST build_components)
+  # GCC 14 + C++20: ClosureControl structs need same-type operator== for std::optional.
+  file(TO_CMAKE_PATH "${CMAKE_SOURCE_DIR}/patches/matter_closure_patch.h" MATTER_CLOSURE_PATCH_H)
+  string(REPLACE "\\" "/" MATTER_CLOSURE_PATCH_H "${MATTER_CLOSURE_PATCH_H}")
+  idf_component_get_property(esp_matter_lib espressif__esp_matter COMPONENT_LIB)
+  target_compile_options(${esp_matter_lib} PRIVATE
+      "SHELL:-include \"${MATTER_CLOSURE_PATCH_H}\"")
+endif()

--- a/configs/defconfig.esp32c5
+++ b/configs/defconfig.esp32c5
@@ -48,20 +48,16 @@ CONFIG_OPENTHREAD_NETWORK_PSKC="104810e2315100afd6bc9215a6bfac53"
 # end of OpenThread
 
 # Matter settings: OpenThread + No CHIPoBLE
-# CONFIG_ENABLE_CHIPOBLE=n
-
-CONFIG_ENABLE_MATTER_OVER_THREAD=y
+CONFIG_ENABLE_CHIPOBLE=y
+CONFIG_ENABLE_MATTER_OVER_THREAD=n
 
 # Set endpoint id for Thread and Wi-Fi, depending on the secondary network interface endpoint id.
 CONFIG_THREAD_NETWORK_ENDPOINT_ID=2
 CONFIG_WIFI_NETWORK_ENDPOINT_ID=0
 
-# Attempt to enable WiFi with 5GHz mode - default is WiFi enabled
-# CONFIG_ENABLE_WIFI_AP=n
-# CONFIG_ENABLE_WIFI_STATION=n
-
-# Last attempt to make it run with Matter over WiFi due to RAM restrictions
-CONFIG_ENABLE_CHIPOBLE=y
+# Attempt to enable WiFi with 5GHz mode - default is WiFi enabled + Disable AP
+CONFIG_ENABLE_WIFI_STATION=y
+CONFIG_ENABLE_WIFI_AP=n
 
 # --- Wi-Fi buffers: balanced for general use + PSRAM-disabled Matter S3/C5 lack of HEAP issue ---
 # Enables a free TX-buffer choice, removes the internal cache-TX pool

--- a/configs/defconfig.esp32s3
+++ b/configs/defconfig.esp32s3
@@ -30,8 +30,8 @@ CONFIG_LCD_RGB_RESTART_IN_VSYNC=y
 
 # Matter settings:
 CONFIG_ENABLE_CHIPOBLE=y
-# NO->RAM issue :: increase the maximum number of endpoints per device
-# CONFIG_ESP_MATTER_MAX_DYNAMIC_ENDPOINT_COUNT=32
+# increase the maximum number of endpoints per device
+CONFIG_ESP_MATTER_MAX_DYNAMIC_ENDPOINT_COUNT=32
 
 # --- Wi-Fi buffers: balanced for general use + PSRAM-disabled Matter S3/C5 lack of HEAP issue ---
 # Enables a free TX-buffer choice, removes the internal cache-TX pool

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -17,7 +17,7 @@ dependencies:
     rules:
       - if: "target in [esp32s3]"
   espressif/esp_matter:
-    version: "1.4.1"
+    version: "1.5"
     require: public
     rules:
       - if: "target not in [esp32c2, esp32p4, esp32c61]"

--- a/patches/matter_closure_patch.h
+++ b/patches/matter_closure_patch.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// GCC 14 + C++20 requires same-type operator== for std::optional<T> comparison.
+// ClosureControl structs only define operator==(const BaseType&), which is not
+// sufficient. This header adds free-function operators via ADL without modifying
+// managed_components. Applied to espressif__esp_matter via CMake -include.
+
+#ifdef __cplusplus
+
+#include "app/clusters/closure-control-server/closure-control-cluster-objects.h"
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace ClosureControl {
+
+inline bool operator==(const GenericOverallCurrentState & a, const GenericOverallCurrentState & b)
+{
+    return a.position == b.position && a.latch == b.latch &&
+           a.speed == b.speed && a.secureState == b.secureState;
+}
+
+inline bool operator==(const GenericOverallTargetState & a, const GenericOverallTargetState & b)
+{
+    return a.position == b.position && a.latch == b.latch && a.speed == b.speed;
+}
+
+} // namespace ClosureControl
+} // namespace Clusters
+} // namespace app
+} // namespace chip
+
+#endif // __cplusplus


### PR DESCRIPTION
## Description

Prepare Arduino Core 3.x and potentially Core 4.x for upgrading Arduino Matter Library to use ESP-Matter v1.5

## Related
https://github.com/espressif/arduino-esp32/pull/12730

## Testing
CI and real Matter testing with the examples
